### PR TITLE
Changes in AggregateRoot for less coupling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 target
+*.iml

--- a/src/main/java/co/com/sofka/domain/generic/AggregateRoot.java
+++ b/src/main/java/co/com/sofka/domain/generic/AggregateRoot.java
@@ -6,11 +6,11 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public abstract class AggregateRoot extends Entity<AggregateRootId> {
+public abstract class AggregateRoot<T extends  AggregateRootId> extends Entity<T> {
     private final List<DomainEvent> changes;
     private final List<Consumer<? super DomainEvent>> handleActions;
 
-    public AggregateRoot(AggregateRootId aggregateRootId) {
+    public AggregateRoot(T aggregateRootId) {
         super(aggregateRootId);
         changes = new LinkedList<>();
         handleActions = new LinkedList<>();

--- a/src/main/java/co/com/sofka/domain/generic/Entity.java
+++ b/src/main/java/co/com/sofka/domain/generic/Entity.java
@@ -1,5 +1,6 @@
 package co.com.sofka.domain.generic;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public abstract class Entity<I> {
@@ -10,5 +11,18 @@ public abstract class Entity<I> {
 
     public UUID generateIdentity(){
         return UUID.randomUUID();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Entity<?> entity = (Entity<?>) o;
+        return Objects.equals(entityId, entity.entityId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entityId);
     }
 }


### PR DESCRIPTION
Se realizó el cambio de la clase para que sea agnóstico a cualquier tipo de la clase AggregateRootId